### PR TITLE
Add multi-network support and camera image fetch

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ class BlinkCamera
 * `blinkCamera.setMotionDetect(boolean)` - set motion detection
 * `blinkCamera.update` - update camera information; internal use
 * `blinkCamera.imageRefresh` - refresh current thumbnail
+* `blinkCamera.fetchImageData` - get the image data for the camera's current thumbnail
 
 # License 
 MIT

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ class Blink
 * `blink.setArmed(boolean)` - arm/disarm the system; `true` by default
 * `blink.getCameras` - find and creates cameras; used for internal purposes
 * `blink.getLinks` - set access links and required headers for each camera in system; used for internal purposes
-* `blink.setupSystem` - logs in and sets auth token, urls, and ids for future requests
+* `blink.setupSystem([system name or id])` - logs in and sets auth token, urls, and ids for future requests. Specify a system identifier if you have more than one system setup.
 * `blink.getIDs` - set the network ID and Account ID; used for internal purpose
 * `blink.getClients` - get information about devices that have connected to the system
 

--- a/lib/blink.js
+++ b/lib/blink.js
@@ -72,7 +72,6 @@ module.exports = class Blink {
       if (!this._auth_header) {
         reject(new BlinkException("Authentication token must be set"));
       }
-
       request({
         url: this.urls.home_url,
         headers: this._auth_header,
@@ -197,6 +196,7 @@ module.exports = class Blink {
   }
 
   getCameras() {
+
     return this.getSummary()
       .then(summary => {
         summary.devices.forEach(device => {
@@ -225,14 +225,13 @@ module.exports = class Blink {
     }
   }
 
-  setupSystem() {
+  setupSystem(name_or_id) {
     if (!this._username || !this._password) {
       throw new BlinkAuthenticationException("Username and password are required for system setup");
-
     }
 
     return this._getAuthToken()
-      .then(this.getIDs.bind(this))
+      .then(() => this.getIDs.bind(this)(name_or_id))
       .then(this.getCameras.bind(this))
       .then(this.getLinks.bind(this));
   }
@@ -307,7 +306,7 @@ module.exports = class Blink {
     });
   }
 
-  getIDs() {
+  getIDs(name_or_id) {
     return new Promise((resolve, reject) => {
       if (!this._auth_header) {
         reject(BlinkException("You have to be authenticated before calling this method"));
@@ -320,8 +319,24 @@ module.exports = class Blink {
         if (err) {
           reject(new BlinkException(`Can't retrieve system status`));
         } else {
-          this._network_id = body.networks[0].id;
-          this._account_id = body.networks[0].account_id;
+          var network = false;
+          if (typeof name_or_id != 'undefined') {
+            body.networks.forEach(function(n){
+              if (n.id == name_or_id || n.name == name_or_id) {
+                network = n;
+              }
+            });
+
+            if (!network) {
+              reject(new BlinkException("No network found for " + name_or_id));
+            }
+          } else {
+            network = body.networks[0];
+          }
+
+          this._network_id = network.id;
+          this._account_id = network.account_id;
+          this.urls = new BlinkURLHandler(this.regionId, this.networkId);
           resolve(this);
         }
       });

--- a/lib/blink.js
+++ b/lib/blink.js
@@ -72,6 +72,7 @@ module.exports = class Blink {
       if (!this._auth_header) {
         reject(new BlinkException("Authentication token must be set"));
       }
+
       request({
         url: this.urls.home_url,
         headers: this._auth_header,
@@ -196,7 +197,6 @@ module.exports = class Blink {
   }
 
   getCameras() {
-
     return this.getSummary()
       .then(summary => {
         summary.devices.forEach(device => {
@@ -228,6 +228,7 @@ module.exports = class Blink {
   setupSystem(name_or_id) {
     if (!this._username || !this._password) {
       throw new BlinkAuthenticationException("Username and password are required for system setup");
+
     }
 
     return this._getAuthToken()

--- a/lib/blink.js
+++ b/lib/blink.js
@@ -264,7 +264,7 @@ module.exports = class Blink {
           'TOKEN_AUTH': this._token
         };
 
-        this.urls = new BlinkURLHandler(this._region_id);
+        this.urls = new BlinkURLHandler(this._region_id, this._network_id);
         resolve(true);
       };
 

--- a/lib/blink_camera.js
+++ b/lib/blink_camera.js
@@ -192,4 +192,20 @@ module.exports = class BlinkCamera {
       })
     });
   }
+
+  fetchImageData() {
+    return new Promise((resolve, reject) => {
+      request({
+        url: this.thumbnail,
+        headers: this._header,
+        encoding: null
+      }, (err, response, body) => {
+        if (err) {
+          reject(new BlinkException(`Can't refresh thumbnail for camera ${this._id}:${this._name}`));
+        } else {
+          resolve(body);
+        }
+      })
+    });
+  }
 };

--- a/lib/blink_url_handler.js
+++ b/lib/blink_url_handler.js
@@ -3,11 +3,15 @@
  */
 
 module.exports = class BlinkURLHandler {
-  constructor(region_id) {
+  constructor(region_id, network_id) {
     this.base_url = 'https://' + region_id + '.' + BLINK_URL;
-    this.home_url = this.base_url + '/homescreen';
     this.event_url = this.base_url + '/events/network/';
     this.network_url = this.base_url + '/network/';
     this.networks_url = this.base_url + '/networks';
+    if (network_id) {
+        this.home_url = this.network_url + network_id + '/homescreen';
+    } else {
+        this.home_url = this.base_url + '/homescreen';
+    }
   }
 };


### PR DESCRIPTION
This adds support for setups that include more than one blink network/system.

It also adds a fetchImageData function do the blinkCamera object so that you can fetch the binary of the camera's thumbnail using the correct auth.