### PR TITLE
Support auth-token login

### DIFF
--- a/lib/blink.js
+++ b/lib/blink.js
@@ -11,7 +11,7 @@ const BlinkURLHandler = require('./blink_url_handler');
 const request = require('request');
 
 module.exports = class Blink {
-  constructor(username, password) {
+  constructor(username, password, options) {
     this._username = username;
     this._password = password;
     this._token = null;
@@ -25,6 +25,7 @@ module.exports = class Blink {
     this._cameras = {};
     this._idlookup = {};
     this.urls = null;
+    Object.assign(this, options)
   }
 
   get cameras() {
@@ -226,17 +227,29 @@ module.exports = class Blink {
   }
 
   setupSystem(name_or_id) {
-    if (!this._username || !this._password) {
-      throw new BlinkAuthenticationException("Username and password are required for system setup");
-
+    if ( !((this._username && this._password) || (this._token && this._network_id && this._region_id ))) {
+      throw new BlinkAuthenticationException("(_username, _password) or (_token, _network_id, _region_id) are required for system setup");
     }
-
-    return this._getAuthToken()
-      .then(() => this.getIDs.bind(this)(name_or_id))
+    if(this._token){
+      this._setupWithToken()
+      return this.getIDs(name_or_id)
       .then(this.getCameras.bind(this))
       .then(this.getLinks.bind(this));
+    }
+    else{
+      return this._getAuthToken()
+        .then(() => this.getIDs.bind(this)(name_or_id))
+        .then(this.getCameras.bind(this))
+        .then(this.getLinks.bind(this));
+    }
   }
-
+  _setupWithToken(){
+      this._auth_header = {
+        'Host': this._host,
+        'TOKEN_AUTH': this._token
+      };
+      this.urls = new BlinkURLHandler(this._region_id, this._network_id);
+  }
   _getAuthToken() {
     return new Promise((resolve, reject) => {
       if (typeof this._username != 'string') {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "homepage": "https://github.com/madshall/node-blink-security#readme",
   "engines": {
-    "node": ">=7.7.3"
+    "node": ">=6.0.0"
   },
   "dependencies": {
     "request": "2.81.0"


### PR DESCRIPTION
First off thanks for the library it's been a tremendous help. 

I modified the constructor to support init by re-using an existing auth-token.  For me this helped me limit the active clients in `account/clients`, and also avoid storing my username & password on a third-party.

Here's an example of the updated `Blink()` constructor using `{_token, _region_id, _network_id}`

```
function setupSystem(){
  var blink = new Blink('', '', {_token: process.env.BLINK_AUTH_TOKEN, _region_id: process.env.BLINK_REGION_ID, _network_id:process.env.BLINK_NETWORK_ID});
  // pass the blink instance to the next promise
  return blink.setupSystem().then(() => blink)
}
```