### PR TITLE
Fix dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "node": ">=6.0.0"
   },
   "dependencies": {
-    "request": "2.88.1"
+    "request": "^2.88.0"
   },
   "devDependencies": {
     "chai": "^4.1.2",


### PR DESCRIPTION
This PR corrects the dependency on `request` as version 2.88.1 doesn't exist. The latest version on npm is `2.88.0`