### PR TITLE
npm audit and update outdated devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,13 +34,13 @@
   "devDependencies": {
     "chai": "^4.1.2",
     "chai-as-promised": "^7.1.1",
-    "chai-http": "^3.0.0",
-    "dotenv": "^4.0.0",
+    "chai-http": "^4.3.0",
+    "dotenv": "^8.2.0",
     "eslint": "^6.0.0",
-    "eslint-plugin-chai-friendly": "^0.4.1",
+    "eslint-plugin-chai-friendly": "^0.5.0",
     "istanbul": "^0.4.5",
-    "mocha": "^5.0.0",
-    "nyc": "^14.1.1",
+    "mocha": "^7.0.0",
+    "nyc": "^15.0.0",
     "replay": "^2.1.4"
   }
 }


### PR DESCRIPTION
npm audit and fix outdated dev deps
```

                                                                                
                       === npm audit security report ===                        
                                                                                
┌──────────────────────────────────────────────────────────────────────────────┐
│                                Manual Review                                 │
│            Some vulnerabilities require your attention to resolve            │
│                                                                              │
│         Visit https://go.npm.me/audit-guide for additional guidance          │
└──────────────────────────────────────────────────────────────────────────────┘
┌───────────────┬──────────────────────────────────────────────────────────────┐
│ Low           │ Large gzip Denial of Service                                 │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Package       │ superagent                                                   │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Patched in    │ >=3.7.0                                                      │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Dependency of │ chai-http [dev]                                              │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Path          │ chai-http > superagent                                       │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ More info     │ https://npmjs.com/advisories/479                             │
└───────────────┴──────────────────────────────────────────────────────────────┘
found 1 low severity vulnerability in 742 scanned packages
  1 vulnerability requires manual review. See the full report for details.
```