### PR TITLE
Add camera method `getStatus`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 # node-blink-security
 This is a Node.js version of [this python library](https://github.com/fronzbot/blinkpy). It allows to communicate with Blink Home Security System from a Node.js application.
-  
+
 # Installation
 ```
 npm install node-blink-security
@@ -97,6 +97,7 @@ class BlinkCamera
 
 ## Methods
 
+* `blinkCamera.getStatus` - get current status
 * `blinkCamera.snapPicture` - take a picture with camera to create a new thumbnail
 * `blinkCamera.setMotionDetect(boolean)` - set motion detection
 * `blinkCamera.update` - update camera information; internal use
@@ -104,7 +105,7 @@ class BlinkCamera
 * `blinkCamera.fetchImageData` - get the image data for the camera's current thumbnail
 * `blinkCamera.recordClip` - record video clip from the camera
 
-# License 
+# License
 MIT
 
 # This is awesome!

--- a/lib/blink_camera.js
+++ b/lib/blink_camera.js
@@ -144,6 +144,22 @@ module.exports = class BlinkCamera {
     this._network_id = value;
   }
 
+  getStatus() {
+    return new Promise((resolve, reject) => {
+      request({
+        url: this._arm_link,
+        json: true,
+        headers: this._header,
+      }, (err, response, {camera_status}) => {
+        if (err) {
+          reject(new BlinkException(`Can't get status from camera ${this._id}:${this._name}`));
+        } else {
+          resolve(camera_status);
+        }
+      });
+    });
+  }
+
   snapPicture() {
     return new Promise((resolve, reject) => {
       request.post({
@@ -157,7 +173,7 @@ module.exports = class BlinkCamera {
         } else {
           resolve(body);
         }
-      })
+      });
     });
   }
 
@@ -174,7 +190,7 @@ module.exports = class BlinkCamera {
         } else {
           resolve(body);
         }
-      })
+      });
     });
   }
 
@@ -210,7 +226,7 @@ module.exports = class BlinkCamera {
           });
           resolve(null);
         }
-      })
+      });
     });
   }
 
@@ -228,7 +244,7 @@ module.exports = class BlinkCamera {
           let status = body;
           resolve(status);
         }
-      })
+      });
     });
   }
 
@@ -244,7 +260,7 @@ module.exports = class BlinkCamera {
         } else {
           resolve(body);
         }
-      })
+      });
     });
   }
 
@@ -260,7 +276,7 @@ module.exports = class BlinkCamera {
         } else {
           resolve(body);
         }
-      })
+      });
     });
   }
 
@@ -277,7 +293,7 @@ module.exports = class BlinkCamera {
         } else {
           resolve(body);
         }
-      })
+      });
     });
   }
 };


### PR DESCRIPTION
This is an incomplete PR as a basis of discussion.  I wanted to be able to query a single camera for its latest thumbnail so I added a `getStatus` request that I discovered [in the protocol](https://github.com/MattTW/BlinkMonitorProtocol#cameras).

I don't know how you might want to integrate it with the `update` method.