### PR TITLE
Workaround misalignment with Blink login API

### DIFF
--- a/lib/blink.js
+++ b/lib/blink.js
@@ -395,7 +395,7 @@ module.exports = class Blink {
         if (err || _statusCodeIsError(response)) {
           return reject(new BlinkAuthenticationException(`Authentication problem: ${body.message}`));
         } else {
-          if ((body.client || {}).verification_required) {
+          if (this.auth_2FA && (body.client || {}).verification_required) {
             if (!this.auth_2FA) {
               if (repeats === 1) return reject(new BlinkAuthenticationException(`Authentication problem: verification timeout`));
               return new Promise((resolve, reject) => {


### PR DESCRIPTION
Please see details in this [Issue](https://github.com/madshall/node-blink-security/issues/55).

## Summary
Blink API is not functioning as it should, this is a workaround

## Details
When using two-factor authentication, a PIN is sent by email but never accepted by the Blink API, thus the login process is stuck.
When not using two-factor authentication, although Blink API returns `"verification_required": true`, an email with a PIN is never sent out, and thus the login process is stuck again.
There is no need for a PIN when not using two-factor authentication, thus this block can be bypassed and the API functions fully.